### PR TITLE
Remove newline after @media, makes css output compatible with stylus

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -53,7 +53,7 @@ Style = (function() {
   };
 
   Style.prototype.wrapMediaQuery = function(css) {
-    return "@media\n(min--moz-device-pixel-ratio: " + this.pixelRatio + "),\n(-o-min-device-pixel-ratio: " + this.pixelRatio + "/1),\n(-webkit-min-device-pixel-ratio: " + this.pixelRatio + "),\n(min-device-pixel-ratio: " + this.pixelRatio + ") {\n" + css + "}\n";
+    return "@media (min--moz-device-pixel-ratio: " + this.pixelRatio + "),\n(-o-min-device-pixel-ratio: " + this.pixelRatio + "/1),\n(-webkit-min-device-pixel-ratio: " + this.pixelRatio + "),\n(min-device-pixel-ratio: " + this.pixelRatio + ") {\n" + css + "}\n";
   };
 
   return Style;

--- a/src/style.coffee
+++ b/src/style.coffee
@@ -53,8 +53,7 @@ class Style
     @cssComment comment
     
   wrapMediaQuery: ( css ) ->
-    "@media\n
-(min--moz-device-pixel-ratio: #{ @pixelRatio }),\n
+    "@media (min--moz-device-pixel-ratio: #{ @pixelRatio }),\n
 (-o-min-device-pixel-ratio: #{ @pixelRatio }/1),\n
 (-webkit-min-device-pixel-ratio: #{ @pixelRatio }),\n
 (min-device-pixel-ratio: #{ @pixelRatio }) {\n


### PR DESCRIPTION
The CSS output of node-spritesheet is almost compatible with stylus, apart from an extraneous newline after the `@media` keyword.

Removing the extra newline means the CSS can be treated as pure stylus, and used for `@extend` queries etc...
