### PR TITLE
httpImagePath option so path in CSS can differ from output directory

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -176,15 +176,16 @@ SpriteSheetConfiguration = (function() {
     this.downsampling = options.downsampling;
     this.pixelRatio = options.pixelRatio || 1;
     this.name = options.name || "default";
+    if (options.outputStyleDirectoryPath) {
+      this.outputStyleDirectoryPath = options.outputStyleDirectoryPath;
+    }
     if (options.outputImage) {
       this.outputImageFilePath = [this.outputDirectory, options.outputImage].join(separator);
       this.outputImageDirectoryPath = path.dirname(this.outputImageFilePath);
+      this.httpImagePath = options.httpImagePath || path.relative(this.outputStyleDirectoryPath, this.outputImageFilePath);
     }
     if (options.outputStyleFilePath) {
       this.outputStyleFilePath = options.outputStyleFilePath;
-    }
-    if (options.outputStyleDirectoryPath) {
-      this.outputStyleDirectoryPath = options.outputStyleDirectoryPath;
     }
     this.style = new Style(options);
   }
@@ -238,10 +239,8 @@ SpriteSheetConfiguration = (function() {
   };
 
   SpriteSheetConfiguration.prototype.generateCSS = function() {
-    var relativeImagePath;
-    relativeImagePath = path.relative(this.outputStyleDirectoryPath, this.outputImageFilePath);
     return this.css = this.style.generate({
-      relativeImagePath: relativeImagePath,
+      relativeImagePath: this.httpImagePath,
       images: this.images,
       pixelRatio: this.pixelRatio
     });

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -140,16 +140,17 @@ class SpriteSheetConfiguration
     
     # The pseudonym for which this configuration should be referenced, e.g. "retina".
     @name = options.name || "default"
+
+    if options.outputStyleDirectoryPath
+      @outputStyleDirectoryPath   = options.outputStyleDirectoryPath
     
     if options.outputImage
       @outputImageFilePath        = [ @outputDirectory, options.outputImage ].join( separator )
       @outputImageDirectoryPath   = path.dirname( @outputImageFilePath )
+      @httpImagePath              = options.httpImagePath || path.relative( @outputStyleDirectoryPath, @outputImageFilePath )
 
     if options.outputStyleFilePath
       @outputStyleFilePath        = options.outputStyleFilePath
-
-    if options.outputStyleDirectoryPath
-      @outputStyleDirectoryPath   = options.outputStyleDirectoryPath
 
     @style = new Style( options )
 
@@ -208,9 +209,8 @@ class SpriteSheetConfiguration
       callback null, image
   
   generateCSS: =>
-    relativeImagePath = path.relative( @outputStyleDirectoryPath, @outputImageFilePath )
     @css = @style.generate
-      relativeImagePath: relativeImagePath
+      relativeImagePath: @httpImagePath
       images: @images
       pixelRatio: @pixelRatio
 


### PR DESCRIPTION
Adds an extra option, `httpImagePath`, that you can set to override the file path that's output in the CSS. This is useful when you're doing URL rewriting on the server, or serving your image assets from a separate CDN to your CSS.
