### PR TITLE
Retina CSS is generated with background-size and correctly scaled size

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -243,7 +243,9 @@ SpriteSheetConfiguration = (function() {
     return this.css = this.style.generate({
       relativeImagePath: relativeImagePath,
       images: this.images,
-      pixelRatio: this.pixelRatio
+      pixelRatio: this.pixelRatio,
+      width: this.layout.width,
+      height: this.layout.height
     });
   };
 

--- a/lib/style.js
+++ b/lib/style.js
@@ -29,13 +29,13 @@ Style = (function() {
   };
 
   Style.prototype.generate = function(options) {
-    var attr, css, image, imagePath, images, pixelRatio, relativeImagePath, styles, _i, _len;
-    imagePath = options.imagePath, relativeImagePath = options.relativeImagePath, images = options.images, pixelRatio = options.pixelRatio;
+    var attr, css, height, image, imagePath, images, pixelRatio, relativeImagePath, styles, width, _i, _len;
+    imagePath = options.imagePath, relativeImagePath = options.relativeImagePath, images = options.images, pixelRatio = options.pixelRatio, width = options.width, height = options.height;
     this.pixelRatio = pixelRatio || 1;
-    styles = [this.css(this.selector, ["  background: url( '" + relativeImagePath + "' ) no-repeat"])];
+    styles = [this.css(this.selector, ["  background: url( '" + relativeImagePath + "' ) no-repeat", "  background-size: " + (width / pixelRatio) + "px " + (height / pixelRatio) + "px"])];
     for (_i = 0, _len = images.length; _i < _len; _i++) {
       image = images[_i];
-      attr = ["  width: " + image.cssw + "px", "  height: " + image.cssh + "px", "  background-position: " + (-image.cssx) + "px " + (-image.cssy) + "px"];
+      attr = ["  width: " + (image.cssw / pixelRatio) + "px", "  height: " + (image.cssh / pixelRatio) + "px", "  background-position: " + (-image.cssx / pixelRatio) + "px " + (-image.cssy / pixelRatio) + "px"];
       image.style = this.cssStyle(attr);
       image.selector = this.resolveImageSelector(image.name, image.path);
       styles.push(this.css([this.selector, image.selector].join('.'), attr));

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -213,6 +213,8 @@ class SpriteSheetConfiguration
       relativeImagePath: relativeImagePath
       images: @images
       pixelRatio: @pixelRatio
+      width: @layout.width
+      height: @layout.height
 
   createSprite: ( callback ) =>
     ImageMagick.composite(

--- a/src/style.coffee
+++ b/src/style.coffee
@@ -21,20 +21,21 @@ class Style
     name
   
   generate: ( options ) ->
-    { imagePath, relativeImagePath, images, pixelRatio } = options
+    { imagePath, relativeImagePath, images, pixelRatio, width, height } = options
     
     @pixelRatio = pixelRatio || 1
   
     styles = [
       @css @selector, [
         "  background: url( '#{ relativeImagePath }' ) no-repeat"
+        "  background-size: #{ width / pixelRatio }px #{ height / pixelRatio }px"
       ]
     ]
     for image in images
       attr = [
-        "  width: #{ image.cssw }px"
-        "  height: #{ image.cssh }px"
-        "  background-position: #{ -image.cssx }px #{ -image.cssy }px"
+        "  width: #{ image.cssw / pixelRatio }px"
+        "  height: #{ image.cssh / pixelRatio }px"
+        "  background-position: #{ -image.cssx / pixelRatio }px #{ -image.cssy / pixelRatio }px"
       ]
       image.style = @cssStyle attr
       image.selector = @resolveImageSelector( image.name, image.path )


### PR DESCRIPTION
Changes the way retina CSS is output, so the dimensions are specified independent of the file's resolution and the background image resized with `background-size`. See: [Retina displays, high-res background images](http://stackoverflow.com/questions/16154494/retina-displays-high-res-background-images) and [5 Things I Learned Designing For High-Resolution Retina Displays](http://www.leemunroe.com/designing-for-high-resolution-retina-displays/) for examples.

Without this change, retina sprites aren't displayed properly and appear at full pixel size in the browser.
