### PR TITLE
Outputted CSS file will only have one width/height declaration if the images are the same size.

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -32,11 +32,27 @@ Style = (function() {
     var attr, css, image, imagePath, images, pixelRatio, relativeImagePath, styles, _i, _len;
     imagePath = options.imagePath, relativeImagePath = options.relativeImagePath, images = options.images, pixelRatio = options.pixelRatio;
     this.pixelRatio = pixelRatio || 1;
-    styles = [this.css(this.selector, ["  background: url( '" + relativeImagePath + "' ) no-repeat"])];
+    var _lastWidth = 0, _lastHeight = 0, sameSize = true;
+    _lastWidth = images[0].cssw;
+    _lastHeight= images[0].cssh;
+
+    for (_i = 0, _len = images.length; _i < _len; _i++) {
+       if (_lastWidth != images[0].cssw || _lastHeight != images[0].cssh) {
+           sameSize = false;
+       }
+    }
+
+    if (sameSize)
+      styles = [this.css(this.selector, ["  background: url( '" + relativeImagePath + "' ) no-repeat", "  width: " + _lastWidth + "px", "  height: " + _lastHeight + "px" ])];
+    else
+      styles = [this.css(this.selector, ["  background: url( '" + relativeImagePath + "' ) no-repeat"])];
+
     for (_i = 0, _len = images.length; _i < _len; _i++) {
       image = images[_i];
-      attr = ["  width: " + image.cssw + "px", "  height: " + image.cssh + "px", "  background-position: " + (-image.cssx) + "px " + (-image.cssy) + "px"];
-      image.style = this.cssStyle(attr);
+      if (sameSize)
+         attr = ["  background-position: " + (-image.cssx) + "px " + (-image.cssy) + "px"];
+      else
+         attr = ["  width: " + image.cssw + "px", "  height: " + image.cssh + "px", "  background-position: " + (-image.cssx) + "px " + (-image.cssy) + "px"];      image.style = this.cssStyle(attr);
       image.selector = this.resolveImageSelector(image.name, image.path);
       styles.push(this.css([this.selector, image.selector].join('.'), attr));
     }

--- a/lib/style.js
+++ b/lib/style.js
@@ -37,7 +37,7 @@ Style = (function() {
     _lastHeight= images[0].cssh;
 
     for (_i = 0, _len = images.length; _i < _len; _i++) {
-       if (_lastWidth != images[0].cssw || _lastHeight != images[0].cssh) {
+       if (_lastWidth != images[_i].cssw || _lastHeight != images[_i].cssh) {
            sameSize = false;
        }
     }


### PR DESCRIPTION
If all the images have the same size, then ensure that the size is only output once. Useful if you have a bunch of images that are all the same size in one sprite.
