### PR TITLE
force windows paths to have slashes instead of backslashes

### DIFF
--- a/src/style.coffee
+++ b/src/style.coffee
@@ -22,7 +22,7 @@ class Style
   
   generate: ( options ) ->
     { imagePath, relativeImagePath, images, pixelRatio, width, height } = options
-    
+    relativeImagePath = relativeImagePath.replace /(\\+)/g, "/"
     @pixelRatio = pixelRatio || 1
   
     styles = [


### PR DESCRIPTION
On Windows, background url used to looks like this:

``` css
background: url( '..\images\sprites.png' ) no-repeat;
```

which can have unwanted effects in the wild.

This PR fixes this
