### PR TITLE
add conditional use of mv or move to enable use in windows

### DIFF
--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -30,7 +30,8 @@ class SpriteSheetBuilder
       if supported
         crushed = "#{ image }.crushed"
         console.log "\n  pngcrushing, this may take a few moments...\n"
-        exec "pngcrush -reduce #{ image } #{ crushed } && mv #{ crushed } #{ image }", ( error, stdout, stderr ) =>
+        movecmd = if process.platform != "win32" then "mv" else "move"
+        exec "pngcrush -reduce #{ image } #{ crushed } && #{ movecmd } #{ crushed } #{ image }", ( error, stdout, stderr ) =>
           callback()
       else
         callback()

--- a/src/imagemagick.coffee
+++ b/src/imagemagick.coffee
@@ -63,11 +63,12 @@ class ImageMagick
     if downsampling
       command += "-filter #{ downsampling }"
       
+    movecmd = if process.platform != "win32" then "mv" else "move"  
     command += "
       #{ image.path } #{ filepath } #{ filepath }.tmp
       
       &&
-      mv #{ filepath }.tmp #{ filepath }
+      #{ movecmd } #{ filepath }.tmp #{ filepath }
     "
   
     exec command, ( error, stdout, stderr ) ->


### PR DESCRIPTION
The tool seemingly works perfect on windows other than the call to mv breaking (the like command is "move" in windows). Just uses a variable to decide which one to use. I've only been able to test it on Win8 x64 and Ubuntu Server 12.04 x64, but it works as expected in both cases. 
