### PR TITLE
add options 'alwaysGrowRight' and 'alwaysGrowDown'

### DIFF
--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -126,6 +126,8 @@ class SpriteSheetConfiguration
   constructor: ( files, options ) ->
     throw "no selector specified" if !options.selector
     
+    @options = options
+
     @images = []
     @filter = options.filter
     @outputDirectory = path.normalize options.outputDirectory

--- a/src/layout.coffee
+++ b/src/layout.coffee
@@ -32,7 +32,7 @@ class Layout
         @placeImage( i, node, hpadding, vpadding, hmargin, vmargin )
         @splitNode( node, i.w, i.h )
       else
-        root = @grow( root, i.w, i.h )
+        root = @grow( root, i.w, i.h, options )
         lp i
   
     for i in images
@@ -75,13 +75,13 @@ class Layout
       w: node.w - w
       h: h
   
-  grow: ( root, w, h ) ->
+  grow: ( root, w, h, options ) ->
   
     canGrowDown  = ( w <= root.w )
     canGrowRight = ( h <= root.h )
   
-    shouldGrowRight = canGrowRight && ( root.h >= ( root.w + w ) )
-    shouldGrowDown  = canGrowDown  && ( root.w >= ( root.h + h ) )
+    shouldGrowRight = options.alwaysGrowRight || ( canGrowRight && ( root.h >= ( root.w + w ) ))
+    shouldGrowDown  = options.alwaysGrowDown || ( canGrowDown  && ( root.w >= ( root.h + h ) ))
   
     if shouldGrowRight
       @growRight root, w, h


### PR DESCRIPTION
It can be useful to be able to generate sprites that only grow right or down. I needed that to generate a sprite that I can animate using css, like in this fiddle:

http://jsfiddle.net/simurai/CGmCe/

I added the options 'alwaysGrowRight' and 'alwaysGrowDown' to enable this behavior in node-spritesheet. Worked like a charm, so I thought I create a pull-request.

The thing is I never wrote any CoffeeScript before and there is probably a much more elegant way to make 'options' a class variable (see the change in builder.coffee, line 129+).
