### PR TITLE
Remedy errant spacing in ImageMagic compose cmd building.

### DIFF
--- a/src/imagemagick.coffee
+++ b/src/imagemagick.coffee
@@ -61,11 +61,10 @@ class ImageMagick
       "
     
     if downsampling
-      command += "-filter #{ downsampling }"
+      command += " -filter #{ downsampling }"
       
     movecmd = if process.platform != "win32" then "mv" else "move"  
-    command += "
-      #{ image.path } #{ filepath } #{ filepath }.tmp
+    command += " #{ image.path } #{ filepath } #{ filepath }.tmp
       
       &&
       #{ movecmd } #{ filepath }.tmp #{ filepath }


### PR DESCRIPTION
CoffeeScript trims leading/trailing spaces from multi-line strings,
so we ended up with filenames and flags occasionally jammed against the
geometry portion.
