### PR TITLE
stopped grunt from executing during install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 node_modules
 *.log
 bin
+lib

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     },
     "main": "./index",
     "scripts": {
-        "install": "grunt"
+        "prepublish": "grunt"
     },
     "dependencies": {
         "async": "~0.1.22",
         "q-fs": "~0.1.32",
-        "underscore": "~1.4.2",
+        "underscore": "~1.4.2"
+    },
+    "devDependencies": {
         "grunt": "~0.4.1",
         "grunt-contrib-coffee": "~0.7.0",
         "grunt-contrib-clean": "~0.5.0"


### PR DESCRIPTION
Instead of generating the `lib/*.js` javascript from the `src/*.coffee` files during install, they are generated before this package is published. This means that installation is a little quicker and simpler for all users and is [recommended by npm](https://www.npmjs.org/doc/misc/npm-scripts.html#NOTE-INSTALL-SCRIPTS-ARE-AN-ANTIPATTERN).

As a bonus, grunt and its plugins are just dev dependencies. Also, unlike #40, the generated `lib/*.js` files do not need to be checked in.
