### PR TITLE
add option to suppress warnings

### DIFF
--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -54,6 +54,11 @@ class SpriteSheetBuilder
     @files = options.images
     @outputConfigurations = {}
     @outputDirectory = path.normalize( options.outputDirectory )
+
+    if options.hasOwnProperty 'failOnWarning'
+      ImageMagick.failOnWarning = options.failOnWarning
+    else
+      ImageMagick.failOnWarning = true
     
     if options.outputCss
       @outputStyleFilePath        = [ @outputDirectory, options.outputCss ].join( separator )

--- a/src/imagemagick.coffee
+++ b/src/imagemagick.coffee
@@ -4,9 +4,9 @@ async         = require( 'async' )
 class ImageMagick
   
   identify: ( filepath, callback ) ->
-    @exec "identify #{ filepath }", ( error, stdout ) ->
-      if error
-        throw "Error in identify (#{ filepath }): #{ error }"
+    @exec "identify #{ filepath }", ( error, stdout, stderr ) =>
+      if error || (stderr && @failOnWarning)
+        throw "Error in identify (#{ filepath }): #{ error || stderr }"
       
       parts = stdout.split " "
       dims = parts[ 2 ].split "x"
@@ -37,9 +37,9 @@ class ImageMagick
       #{ filepath }
     "
     
-    @exec command, ( error, stdout ) =>
-      if error
-        throw "Error in creating canvas (#{ filepath }): #{ error }"
+    @exec command, ( error, stdout, stderr ) =>
+      if error || (stderr && @failOnWarning)
+        throw "Error in creating canvas (#{ filepath }): #{ error || stderr }"
       
       compose = ( image, next ) =>
         console.log "    Composing #{ image.path }"
@@ -71,9 +71,9 @@ class ImageMagick
       #{ movecmd } #{ filepath }.tmp #{ filepath }
     "
   
-    exec command, ( error, stdout ) ->
-      if error
-        throw "Error in composite (#{ filepath }): #{ error }"
+    exec command, ( error, stdout, stderr ) ->
+      if error || (stderr && @failOnWarning)
+        throw "Error in composite (#{ filepath }): #{ error || stderr }"
       
       callback()
 

--- a/src/imagemagick.coffee
+++ b/src/imagemagick.coffee
@@ -4,9 +4,9 @@ async         = require( 'async' )
 class ImageMagick
   
   identify: ( filepath, callback ) ->
-    @exec "identify #{ filepath }", ( error, stdout, stderr ) ->
-      if error or stderr
-        throw "Error in identify (#{ filepath }): #{ error || stderr }"
+    @exec "identify #{ filepath }", ( error, stdout ) ->
+      if error
+        throw "Error in identify (#{ filepath }): #{ error }"
       
       parts = stdout.split " "
       dims = parts[ 2 ].split "x"
@@ -37,9 +37,9 @@ class ImageMagick
       #{ filepath }
     "
     
-    @exec command, ( error, stdout, stderr ) =>
-      if error or stderr
-        throw "Error in creating canvas (#{ filepath }): #{ error || stderr }"
+    @exec command, ( error, stdout ) =>
+      if error
+        throw "Error in creating canvas (#{ filepath }): #{ error }"
       
       compose = ( image, next ) =>
         console.log "    Composing #{ image.path }"
@@ -71,9 +71,9 @@ class ImageMagick
       #{ movecmd } #{ filepath }.tmp #{ filepath }
     "
   
-    exec command, ( error, stdout, stderr ) ->
-      if error or stderr
-        throw "Error in composite (#{ filepath }): #{ error || stderr }"
+    exec command, ( error, stdout ) ->
+      if error
+        throw "Error in composite (#{ filepath }): #{ error }"
       
       callback()
 


### PR DESCRIPTION
This PR adds a `failOnWarning` option. It defaults to true, and the behavior of
the module is the same. If passed something falsy, however, it will not fail
when there is no `error` and just `stderr` output from ImageMagick commands.
