### PR TITLE
require grunt-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     },
     "dependencies": {
         "async": "~0.1.22",
-        "q-fs": "~0.1.32",
-        "underscore": "~1.4.2",
         "grunt": "~0.4.1",
+        "grunt-cli": "^0.1.13",
+        "grunt-contrib-clean": "~0.5.0",
         "grunt-contrib-coffee": "~0.7.0",
-        "grunt-contrib-clean": "~0.5.0"
+        "q-fs": "~0.1.32",
+        "underscore": "~1.4.2"
     }
 }


### PR DESCRIPTION
Otherwise, install fails for any environment that doesn't have grunt-cli installed globally.
