### PR TITLE
Support global and configuration-specific icon margin and padding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ highest density has been supplied).
                 // Optional absolute path to output image.
                 httpImagePath: "http://static.mysite.com/images/sprite.png",
                 
+                // Optional padding and margin on each icon in the output image.
+                // Padding adds whitespace around each icon. Padding sometimes
+                // prevents icons from appearing "cut off" when the user uses
+                // browser zoom.
+                hpadding: 5,
+                vpadding: 5,
+                // Margin adds whitespace between icons in the output image, not
+                // affecting the size of each icon. Margin helps icons not spill
+                // into each other when the user uses browser zoom.
+                hmargin: 10,
+                vmargin: 10,
+                
                 // Output configurations: in this instance to output two sprite sheets,
                 // one for "legacy" (i.e. 72dpi, pixel ratio 1), and "retina" (x2).
                 // These keys (legacy, retina) are completely arbitrary.
@@ -217,6 +229,12 @@ resampling option, if you want finer control.
                     retina: {
                         pixelRatio: 2,
                         outputImage: 'sprite@2x.png',
+                        // Set extra margin only in the retina spritesheet. You can
+                        // also set a custom padding here that just applies to the
+                        // retina icon set, but doing so results in the icons being
+                        // different sizes between non-retina and retina.
+                        hmargin: 20,
+                        vmargin: 20,
                         // Just process the retina files
                         filter: function( fullpath ) {
                             return fullpath.indexOf( "@2x" ) >= 0;

--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -43,9 +43,17 @@ class SpriteSheetBuilder
     delete options.output
     
     if outputConfigurations && Object.keys( outputConfigurations ).length > 0
+      configurationSpecificSpacing = _.any outputConfigurations, (config) ->
+        _.has(config, 'hpadding') ||
+        _.has(config, 'vpadding') ||
+        _.has(config, 'hmargin') ||
+        _.has(config, 'vmargin')
+      if configurationSpecificSpacing
+        console.log "Detected configuration-specific padding/margin. Including custom positioning declarations for every media query block.\n"
     
       for key of outputConfigurations
         config = outputConfigurations[ key ]
+        config.alwaysIncludeSpacing = configurationSpecificSpacing
         builder.addConfiguration( key, config )
       
     return builder
@@ -154,6 +162,8 @@ class SpriteSheetConfiguration
       @outputStyleFilePath        = options.outputStyleFilePath
 
     @style = new Style( options )
+
+    @options = _.extend {}, options,
 
   build: ( callback ) =>
     throw "No output image file specified"    if !@outputImageFilePath

--- a/src/style.coffee
+++ b/src/style.coffee
@@ -5,6 +5,7 @@ class Style
   constructor: ( options ) ->
     @selector = options.selector
     @pixelRatio = options.pixelRatio || 1
+    @alwaysIncludeSpacing = options.alwaysIncludeSpacing
     
     @resolveImageSelector = options.resolveImageSelector if options.resolveImageSelector
 
@@ -33,7 +34,7 @@ class Style
     ]
 
     # Only add background-position, width and height for pixelRatio === 1.
-    if pixelRatio is 1
+    if @alwaysIncludeSpacing or pixelRatio is 1
       for image in images
         positionX = ( -image.cssx / pixelRatio )
         if positionX != 0


### PR DESCRIPTION
The current SpriteSheetConfiguration.prototype.layoutImages implementation draws from an options property that is never set. Set it in the configuration constructor so that {h,v}{padding,margin} can be set in the config. Adding readme sections explaining usage.

To support configuration-specific margin and padding, we need to detect if it's necessary to re-print the entire sizing and background-positioning CSS for every media query block. In the base case (no configuration-specific spacing), the code detects that it's not needed to re-print the sizing declarations in the media query block, so there's no additional file size impact on the base case. In the special case, the full sizing declaration is re-printed in every media query block.

We could be smarter and only re-print if it's necessary (e.g., if there's only custom spacing for 3x pixel ratio but 2x has the same spacing as 1x).
