### PR TITLE
store lost options

### DIFF
--- a/src/builder.coffee
+++ b/src/builder.coffee
@@ -125,7 +125,8 @@ class SpriteSheetConfiguration
 
   constructor: ( files, options ) ->
     throw "no selector specified" if !options.selector
-    
+   
+    @options = options 
     @images = []
     @filter = options.filter
     @outputDirectory = path.normalize options.outputDirectory


### PR DESCRIPTION
in `SpriteSheetConfiguration` class the `options` are never stored, so it's impossible to provide layout settings to the `Layout` class. Fixed it in the simplest way possible
